### PR TITLE
export: false option is not working correctly

### DIFF
--- a/lib/gen.ex
+++ b/lib/gen.ex
@@ -8,10 +8,11 @@ defmodule GenX.Gen do
   def defhandler(callback, {m,f}, {function, _meta, arguments} = name, options, extras) do
     if is_atom(arguments), do: arguments = []
     state = options[:state] || (quote do: _)
-    export_option = case options[:export] do
-                         nil -> []
-                         keyword when is_list(keyword) -> keyword
-                         value -> [server: value]
+    {export_option, no_export} = case options[:export] do
+                         nil -> {[], false}
+                         false -> {[],true}
+                         keyword when is_list(keyword) -> {keyword, false}
+                         value -> {[server: value], false}
                     end
     export = Keyword.merge [server: :server, name: name], export_option
     {function_name, _, _} = export[:name]
@@ -52,8 +53,8 @@ defmodule GenX.Gen do
                              unquote(state)), do: unquote(options[:do])
       unless Module.defines?(__MODULE__,
                                       {unquote(export[:name]),
-                                       unquote(arity)}) and
-             unquote(export[:name]) !== false do
+                                       unquote(arity)}) or 
+             unquote(no_export) do
         def unquote(export[:name])(unquote_splicing(full_arguments)) do
           unquote(m).unquote(f)(unquote_splicing(args))
         end

--- a/test/gen_server_test.exs
+++ b/test/gen_server_test.exs
@@ -92,6 +92,7 @@ defmodule GenX.GenServer.Test do
   test "private call" do
       {:ok, pid} = GS.start_link(S,[],[]) 
       assert not :erlang.function_exported(S, :private_call, 1)
+      assert not :erlang.function_exported(S, :private_call, 0)
       assert GS.call(pid, :private_call) == :ok
   end
 
@@ -181,6 +182,7 @@ defmodule GenX.GenServer.Test do
   test "private info" do
       {:ok, pid} = GS.start_link(S,[],[]) 
       assert not :erlang.function_exported(S, :private_info, 2)
+      assert not :erlang.function_exported(S, :private_info, 1)
       assert (pid <- {:private_info, 123}) == {:private_info, 123}
       assert S.get_state(pid) == 123
   end


### PR DESCRIPTION
Hi,

I found the export: false option on defcall does not actually work, and the tests for it do not detect this because they are testing for a higher arity. What happens is a function is created that will try to send messages to a server named "false", so it has a lower arity than if it had no export statement at all. The changes I made to the gen_server_test.exs will demonstrate the issue. 

I included a fix - I'm not sure its how you would want to do it but there it is if its helpful.

Thanks, Jeremy
