### PR TITLE
Fixed SemVer Compilation Error

### DIFF
--- a/lib/supervisor.ex
+++ b/lib/supervisor.ex
@@ -143,7 +143,7 @@ defmodule GenX.Supervisor do
   defdelegate [supervise(s)], to: Supervision
   defdelegate [supervisor(s), cast(s)], to: Supervisor
 
-  def start_link(sup, {module, args} // {__MODULE__, nil}) do
+  def start_link(sup, {module, args} \\ {__MODULE__, nil}) do
     case sup.registered do
       false ->
         :supervisor.start_link(module, {supervisor(sup), args})

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule GenX.MixFile do
   use Mix.Project
 
   def project do
-    [app: :genx, version: "0.1"]
+    [app: :genx, version: "1.0.0"]
   end
 
   def application, do: []


### PR DESCRIPTION
New Elixir version is now forcing use of semantic versioning.

Also fixed default value in function from `//` to `\\`.
